### PR TITLE
Allow GLava to work without GL_NV_texture_barrier extension

### DIFF
--- a/glava/render.c
+++ b/glava/render.c
@@ -2214,7 +2214,7 @@ bool rd_update(struct glava_renderer* r, float* lb, float* rb, size_t bsz, bool 
                            transformations in-place using a single texture buffer.
                            Without this, we would need to double-buffer our textures
                            and perform pointless copies. */
-                        glTextureBarrierNV();
+                        if (glTextureBarrierNV) glTextureBarrierNV();
                         
                         /* Apply gravity */
                         glUseProgram(gl->gr_prog);


### PR DESCRIPTION
Without this extension, GLava tries to call into a null pointer and segfaults.

Fix: don't call `glTextureBarrierNV` if the extension doesn't exist.

This is potentially unsafe, but appears to work fine in practice.