### PR TITLE
Spelling mistake in CLI messages

### DIFF
--- a/glava-cli/cli.c
+++ b/glava-cli/cli.c
@@ -6,11 +6,11 @@
 static glava_handle handle;
 
 static void handle_term  (int _) {
-    printf("Interrupt recieved, closing...\n");
+    printf("Interrupt received, closing...\n");
     glava_terminate(&handle);
 }
 static void handle_reload(int _) {
-    printf("User signal recieved, reloading...\n");
+    printf("User signal received, reloading...\n");
     glava_reload(&handle);
 }
 


### PR DESCRIPTION
There is a misspelling of "received" in the CLI reload/termination messages.

This PR fixes the spelling mistakes.
